### PR TITLE
Update copy-language-pack.sh

### DIFF
--- a/scripts/copy-language-pack.sh
+++ b/scripts/copy-language-pack.sh
@@ -1,18 +1,35 @@
-browser_locales=engine/browser/locales
+#!/bin/bash
+
+browser_locales="engine/browser/locales"
 
 copy_browser_locales() {
-  langId=$1
-  mkdir -p $browser_locales/$langId
-  if [ "$langId" = "en-US" ]; then
-    find $browser_locales/$langId -type f -name "zen*" -delete
-    rsync -av --exclude=.git ./l10n/en-US/browser/ $browser_locales/$langId/
-    return
+  langId="$1"
+  
+  if [ -z "$langId" ]; then
+    echo "Error: No language ID provided."
+    return 1
   fi
-  rm -rf $browser_locales/$langId/
-  # TODO: Copy the rest of the l10n directories to their respective locations
-  rsync -av --exclude=.git ./l10n/$langId/ $browser_locales/$langId/
+  
+  mkdir -p "$browser_locales/$langId"
+  
+  if [ "$langId" = "en-US" ]; then
+    # Remove any existing files starting with "zen" for en-US
+    find "$browser_locales/$langId" -type f -name "zen*" -delete
+    # Copy the en-US localization files
+    rsync -av --exclude=.git "./l10n/en-US/browser/" "$browser_locales/$langId/"
+  else
+    # Remove any existing localization for the specified language
+    rm -rf "$browser_locales/$langId/"
+    # Copy the localization files for the specified language
+    # Make sure the source directory exists
+    if [ -d "./l10n/$langId/" ]; then
+      rsync -av --exclude=.git "./l10n/$langId/" "$browser_locales/$langId/"
+    else
+      echo "Warning: Localization directory for $langId does not exist. Skipping."
+    fi
+  fi
 }
 
-LANG=$1
+LANG="$1"
 echo "Copying language pack for $LANG"
-copy_browser_locales $LANG
+copy_browser_locales "$LANG"


### PR DESCRIPTION
    Added a check for an empty language ID.
    Wrapped variable expansions in double quotes to prevent issues with spaces.
    Added a check to ensure the source localization directory exists before attempting to copy it, with a warning message if it doesn't.
    Improved comments for better clarity.