### PR TITLE
Potential fix for code scanning alert no. 34: Overly permissive regular expression range

### DIFF
--- a/src/browser/components/preferences/zen-settings.js
+++ b/src/browser/components/preferences/zen-settings.js
@@ -168,7 +168,7 @@ var gZenMarketplaceManager = {
     const themeList = document.createElement('div');
 
     for (const theme of Object.values(themes).sort((a, b) => a.name.localeCompare(b.name))) {
-      const sanitizedName = `theme-${theme.name?.replaceAll(/\s/g, '-')?.replaceAll(/[^A-z_-]+/g, '')}`;
+      const sanitizedName = `theme-${theme.name?.replaceAll(/\s/g, '-')?.replaceAll(/[^A-Za-z_-]+/g, '')}`;
       const isThemeEnabled = theme.enabled === undefined || theme.enabled;
 
       const fragment = window.MozXULElement.parseXULToFragment(`


### PR DESCRIPTION
Potential fix for [https://github.com/cristiancmoises/desktop/security/code-scanning/34](https://github.com/cristiancmoises/desktop/security/code-scanning/34)

To fix the problem, we need to update the regular expression to use the correct range for alphabetic characters. Instead of using `A-z`, we should use `A-Za-z` to match only uppercase and lowercase letters. This change will ensure that the regular expression does not match unintended characters.

- Update the regular expression on line 171 in the file `src/browser/components/preferences/zen-settings.js`.
- Replace the range `A-z` with `A-Za-z` to correctly match only alphabetic characters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
