### PR TITLE
Potential fix for code scanning alert no. 30: If expression always true

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
           bash ./start.sh
 
       - name: Remove self-hosted runner script
-        if: always() && ${{ inputs.create_release && inputs.update_branch == 'release' }}
+        if: ${{ inputs.create_release && inputs.update_branch == 'release' }}
         run: |
           echo "Removing self-hosted runner script"
           rm start.sh || true


### PR DESCRIPTION
Potential fix for [https://github.com/cristiancmoises/desktop/security/code-scanning/30](https://github.com/cristiancmoises/desktop/security/code-scanning/30)

To fix the problem, we need to remove the `always()` function from the `if` condition on line 88. This will ensure that the step only runs if `inputs.create_release` is true and `inputs.update_branch` is equal to 'release'. 

- Remove `always()` from the `if` condition on line 88.
- Ensure the condition is correctly formatted without extra spaces or characters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
